### PR TITLE
Fix AppContext missing error in GitHub Actions build

### DIFF
--- a/src/contexts/AppContext.js
+++ b/src/contexts/AppContext.js
@@ -1,0 +1,45 @@
+import React, { createContext, useState, useContext } from 'react';
+
+// Create the context
+const AppContext = createContext();
+
+// Custom hook to use the context
+export const useAppContext = () => useContext(AppContext);
+
+// Provider component
+export const AppProvider = ({ children }) => {
+  // State variables
+  const [view, setView] = useState('3d'); // Default to 3D view
+  const [showHelp, setShowHelp] = useState(false);
+  const [functionType, setFunctionType] = useState('polynomial');
+  const [integralLimits, setIntegralLimits] = useState({
+    x: { min: -5, max: 5 },
+    y: { min: -5, max: 5 },
+  });
+  const [resolution, setResolution] = useState(30); // Grid resolution
+  const [theme, setTheme] = useState('light');
+
+  // Values to be provided by context
+  const contextValue = {
+    view,
+    setView,
+    showHelp,
+    setShowHelp,
+    functionType,
+    setFunctionType,
+    integralLimits,
+    setIntegralLimits,
+    resolution,
+    setResolution,
+    theme,
+    setTheme,
+  };
+
+  return (
+    <AppContext.Provider value={contextValue}>
+      {children}
+    </AppContext.Provider>
+  );
+};
+
+export default AppContext;


### PR DESCRIPTION
## Description
This PR fixes the build error in GitHub Actions by adding the missing `AppContext.js` file.

### Problem
The build was failing with the error:
```
Module not found: Error: Can't resolve './contexts/AppContext' in '/home/runner/work/3d-integral-explorer/3d-integral-explorer/src'
```

This happened because `App.js` imports `AppProvider` from `./contexts/AppContext`, but the file and directory were missing in the repository.

### Solution
- Created a new `contexts` directory in the `src` folder
- Added `AppContext.js` with a basic React context implementation for application state management
- Implemented common state variables that would be useful for a 3D integral explorer application

This change should fix the GitHub Actions workflow and allow the deployment to complete successfully.
